### PR TITLE
Token storage

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,8 +7,9 @@ var shell = require('gulp-shell');
 // var uglify = require('gulp-uglify');
 var webpack = require('gulp-webpack');
 var webpackConfig = require('./webpack.config.js');
+var tokenWorkerConfig = require('./tokenworker.webpack.config.js');
 
-gulp.task('webpack-app', function() {
+gulp.task('webpack-app', ['webpack-token-worker'], function() {
   return gulp.src('./src/js/index.js')
     .pipe(webpack(webpackConfig))
     .pipe(gulp.dest('dist/js'))
@@ -40,6 +41,13 @@ gulp.task('fonts', function() {
   var bootstrapFonts = 'node_modules/bootstrap/fonts/*';
   return gulp.src([bootstrapFonts])
     .pipe(gulp.dest('./dist/fonts'));
+});
+
+gulp.task('webpack-token-worker', function() {
+    return gulp.src('./src/js/workers/TokenWorker.js')
+        .pipe(webpack(tokenWorkerConfig))
+        .pipe(gulp.dest('./dist/js'))
+        .pipe(browserSync.stream());
 });
 
 // Start test server, run tests once, then quit.

--- a/src/__tests__/actions/LoginActions.tests.js
+++ b/src/__tests__/actions/LoginActions.tests.js
@@ -2,6 +2,7 @@ const AppDispatcher = require('../../js/dispatchers/AppDispatcher');
 const KeystoneApiService = require('../../js/services/KeystoneApiService');
 const LoginActions = require('../../js/actions/LoginActions');
 const LoginConstants = require('../../js/constants/LoginConstants');
+const AuthTokenStorage = require('../../js/services/AuthTokenStorage.js');
 
 let mockKeystoneAccess = {
   token: {
@@ -12,10 +13,6 @@ let mockKeystoneAccess = {
   metadata: 'some metadata'
 };
 
-// Create an empty global `localStorage` variable.
-/*global localStorage:true*/
-localStorage = {};
-
 describe('LoginActions', () => {
   it('creates action to authenticate user via keystone token', () => {
     spyOn(KeystoneApiService, 'authenticateUserViaToken');
@@ -24,10 +21,10 @@ describe('LoginActions', () => {
   });
 
   it('creates action to login user with keystoneAccess response', () => {
-    spyOn(localStorage, 'setItem');
-    spyOn(AppDispatcher, 'dispatch');
+    spyOn(AuthTokenStorage, 'storeTokenId');
+    spyOn(AppDispatcher, 'dispatch').and.callThrough();
     LoginActions.loginUser(mockKeystoneAccess);
-    expect(localStorage.setItem).toHaveBeenCalledWith('keystoneAuthTokenId', mockKeystoneAccess.token.id);
+    expect(AuthTokenStorage.storeTokenId).toHaveBeenCalledWith(mockKeystoneAccess.token.id);
     expect(AppDispatcher.dispatch).toHaveBeenCalledWith({
       actionType: LoginConstants.LOGIN_USER,
       keystoneAccess: mockKeystoneAccess
@@ -35,10 +32,10 @@ describe('LoginActions', () => {
   });
 
   it('creates action to logout user', () => {
-    spyOn(localStorage, 'removeItem');
-    spyOn(AppDispatcher, 'dispatch');
+    spyOn(AuthTokenStorage, 'removeTokenId');
+    spyOn(AppDispatcher, 'dispatch').and.callThrough();
     LoginActions.logoutUser();
-    expect(localStorage.removeItem).toHaveBeenCalledWith('keystoneAuthTokenId');
+    expect(AuthTokenStorage.removeTokenId).toHaveBeenCalled();
     expect(AppDispatcher.dispatch).toHaveBeenCalledWith({
       actionType: LoginConstants.LOGOUT_USER
     });

--- a/src/__tests__/services/AuthTokenStorage.tests.js
+++ b/src/__tests__/services/AuthTokenStorage.tests.js
@@ -1,0 +1,48 @@
+const AuthTokenStorage = require('../../js/services/AuthTokenStorage.js');
+const LoginActions = require('../../js/actions/LoginActions');
+
+describe('AuthTokenStorage.', () => {
+
+    describe('```AuthTokenStorage.getTokenId```', () => {
+
+        let cbObj = { cb: (token) => {} };
+
+        beforeEach(() => {
+            spyOn(cbObj, 'cb');
+        });
+
+        it('calls the given callback with the token if one has been set.',
+                (done) => {
+            LoginActions.loginUser({
+                token: 'token-from-login',
+                user: null,
+                serviceCatalog: null,
+                metadata: null
+            });
+            // unset the sessionStorage value to make sure
+            // the value is retreived from the worker.
+            spyOn(sessionStorage, 'getItem').and.returnValue(null);
+            AuthTokenStorage.getTokenId(cbObj.cb);
+            done();
+            expect(cbObj.cb).toHaveBeenCalledWith('token-from-login');
+        });
+
+        it('gives precedence to the token in sessionStorage if one is set', () => {
+            spyOn(sessionStorage, 'getItem').and.returnValue('token-from-session-storage');
+            AuthTokenStorage.getTokenId(cbObj.cb);
+            expect(cbObj.cb).toHaveBeenCalledWith('token-from-session-storage');
+        });
+
+    });
+
+    describe('```AuthTokenStorage.onLogoutUser```', () => {
+
+        it('removes the token from sessionStorage', () => {
+            spyOn(sessionStorage, 'removeItem');
+            AuthTokenStorage.removeTokenId();
+            expect(sessionStorage.removeItem).toHaveBeenCalledWith('keystoneAuthTokenId');
+        });
+
+    });
+    
+});

--- a/src/js/actions/LoginActions.js
+++ b/src/js/actions/LoginActions.js
@@ -1,4 +1,5 @@
 import AppDispatcher from '../dispatchers/AppDispatcher.js';
+import AuthTokenStorage from '../services/AuthTokenStorage.js';
 import KeystoneApiService from '../services/KeystoneApiService';
 import LoginConstants from '../constants/LoginConstants';
 
@@ -8,7 +9,7 @@ export default {
   },
 
   loginUser(keystoneAccess) {
-    localStorage.setItem('keystoneAuthTokenId', keystoneAccess.token.id);
+    AuthTokenStorage.storeTokenId(keystoneAccess.token.id);
     AppDispatcher.dispatch({
       actionType: LoginConstants.LOGIN_USER,
       keystoneAccess: keystoneAccess
@@ -16,7 +17,7 @@ export default {
   },
 
   logoutUser() {
-    localStorage.removeItem('keystoneAuthTokenId');
+    AuthTokenStorage.removeTokenId();
     AppDispatcher.dispatch({
       actionType: LoginConstants.LOGOUT_USER
     });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -4,6 +4,7 @@ import React from 'react';
 import * as Router from 'react-router';
 
 import App from './components/App';
+import AuthTokenStorage from './services/AuthTokenStorage.js';
 import Login from './components/Login';
 import LoginActions from './actions/LoginActions';
 import Overview from './components/Overview';
@@ -20,11 +21,12 @@ let routes = (
   </Route>
 );
 
-// Login user on page refresh if logged in previously
-let keystoneAuthTokenId = localStorage.getItem('keystoneAuthTokenId');
-if (keystoneAuthTokenId) {
-  LoginActions.authenticateUserViaToken(keystoneAuthTokenId);
-}
+
+AuthTokenStorage.getTokenId((keystoneAuthTokenId) => {
+  if (keystoneAuthTokenId) {
+    LoginActions.authenticateUserViaToken(keystoneAuthTokenId);
+  }
+});
 
 Router.run(routes, Router.HashLocation, (Root) => {
   React.render(<Root/>, document.body);

--- a/src/js/services/AuthTokenStorage.js
+++ b/src/js/services/AuthTokenStorage.js
@@ -1,0 +1,51 @@
+class AuthTokenStorage {
+
+  constructor() {
+    this._createWorkerInstance();
+  }
+
+  _createWorkerInstance() {
+    if(window && window.SharedWorker) {
+      this.worker = new window.SharedWorker('/js/tripleo_ui_token_worker.js');
+      this.worker.port.start();
+    }
+  }
+
+  /**
+   * Get the currently stored token ID.
+   * @returns {String|Boolean} The token Id or false.
+   */
+  getTokenId(cb) {
+    let tokenId = sessionStorage.getItem('keystoneAuthTokenId');
+
+    // If there was a tokenId stored in sessionStorage,
+    // just call the cb and leave.
+    if(tokenId) {
+      return cb(tokenId);
+    }
+
+    // Create callback for temporary worker message listener.
+    let fn = (e) => {
+      cb(e.data);
+      this.worker.port.removeEventListener('message', fn);
+    };
+    this.worker.port.addEventListener('message', fn);
+    this.worker.port.postMessage(null);
+  }
+
+  storeTokenId(tokenId) {
+    sessionStorage.setItem('keystoneAuthTokenId', tokenId);
+    this.worker.port.postMessage(tokenId);
+  }
+
+  removeTokenId() {
+    sessionStorage.removeItem('keystoneAuthTokenId');
+    if(this.worker) {
+      // Post a value of false to erase the token.
+      this.worker.port.postMessage(false);
+    }
+  }
+
+}
+
+export default new AuthTokenStorage();

--- a/src/js/stores/LoginStore.js
+++ b/src/js/stores/LoginStore.js
@@ -2,6 +2,7 @@ import BaseStore from './BaseStore';
 import LoginConstants from '../constants/LoginConstants';
 
 class LoginStore extends BaseStore {
+
   constructor() {
     super();
     this.subscribe(() => this._registerToActions.bind(this));

--- a/src/js/workers/TokenWorker.js
+++ b/src/js/workers/TokenWorker.js
@@ -1,0 +1,16 @@
+let message = undefined;
+
+self.addEventListener('connect', e => {
+
+  let port = e.ports[0];
+
+  port.addEventListener('message', e => {
+    if(e.data !== null) {
+      message = e.data;
+    }
+    port.postMessage(message);
+  }, false);
+
+  port.start();
+
+}, false);

--- a/tokenworker.webpack.config.js
+++ b/tokenworker.webpack.config.js
@@ -1,0 +1,17 @@
+module.exports = {
+    devtool: 'source-map',
+    output: {
+        filename: 'tripleo_ui_token_worker.js',
+        sourceMapFilename: 'tripleo_ui_token_worker.js.map'
+    },
+    module: {
+        loaders: [
+          { test: /\.js$/, include: /src\/js\/workers/, loader: 'babel-loader' }//,
+        ]
+    },
+    node: {
+      fs: 'empty',
+      net: 'empty',
+      tls: 'empty'
+    }
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, include: /src/, exclude: /node_modules/, loader: 'babel-loader' }//,
+      { test: /\.js$/, include: /src/, exclude: /(node_modules|src\/js\/workers)/, loader: 'babel-loader' }//,
       // { test: /disqus-thread.js$/, loader: 'babel-loader' },
       // { test: /\.json$/, loader: 'json-loader' }
     ]


### PR DESCRIPTION
So here's the sessionStorage/webworker-based token storage patch. Most of the functionality is the LoginStore module, as well as the shared webworker module. 

Along with a couple of new tests, I updated two of the older tests in order to work with the changes.

The webworker module has to be compiled into a separate JS file, so I had to make some additions to the webpack conf. 

Cheers and thanks for reviewing.
Florian
